### PR TITLE
Create path recursively

### DIFF
--- a/export-organizer.js
+++ b/export-organizer.js
@@ -59,7 +59,7 @@ if (filenames) {
                     }
 
                     if (!fs.existsSync(exportPath)) {
-                        fs.mkdirSync(exportPath);
+                        fs.mkdirSync(exportPath, { recursive: true });
                     }
 
                     var oldFile = path.format({


### PR DESCRIPTION
fs.mkdirSync has a function to create paths recursively (since nodejs 10.12.0).

This PR prevents the tool bailing should the path need to create folders more than one level deep.

In the example below; "flickrExport/2004" doesn't exist so when "flickrExport/2004/album08" is passed to mkdirSync without recursive set to true, the function fails.
```
fs.js:114
    throw err;
    ^

Error: ENOENT: no such file or directory, mkdir 'flickrExport/2004/album08'
    at Object.mkdirSync (fs.js:757:3)
    at read (/mnt/bertha/tristan/Flickr/extract/export-organizer.js:62:28)
    at FSReqWrap.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:53:3)```